### PR TITLE
🚸 Allow removing owner in fgh ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Get the path of a cloned repository. Usage is as follows:
 fgh ls <owner/name>
 ```
 
+You may omit `owner` if you own the repository, or if there is only one cloned repository with the given `name`.
+
 ### ⬇️ `fgh pull`
 
 Pull all repos that don't have any non-pushed changes. Usage is as follows:

--- a/pkg/repos/filter.go
+++ b/pkg/repos/filter.go
@@ -2,6 +2,7 @@ package repos
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Matt-Gleich/fgh/pkg/commands/clone"
@@ -12,12 +13,23 @@ import (
 func FilterRepos(username string, repos []LocalRepo, args []string) (filtered []LocalRepo) {
 	owner, name := clone.OwnerAndName(username, args)
 	for _, repo := range repos {
-		if strings.EqualFold(repo.Owner, owner) && strings.EqualFold(repo.Name, name) {
+		if strings.EqualFold(repo.Name, name) {
 			filtered = append(filtered, repo)
 		}
 	}
+
+	// Give repos owned by user greater precedence
+	sort.Slice(filtered, func(i int, j int) bool {
+		if filtered[j].Owner == owner && filtered[i].Owner != owner {
+			return false
+		}
+
+		return true
+	})
+
 	if len(filtered) == 0 {
 		statuser.ErrorMsg(fmt.Sprintf("Failed to find %v/%v", owner, name), 1)
 	}
+
 	return filtered
 }


### PR DESCRIPTION
## Description

<!--
Describe your changes in detail
-->

This PR makes `fgh ls` work without an owner. It automatically gives precedence to repos that _do_ match the given owner, so `fgh ls Matt-Gleich/fgh` will first check for a repo owned by `Matt-Gleich`, then look for others with the same name.

## Steps

- [x] My change requires a change to the documentation
- [x] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #25 

<!--
Example:
This PR resolves #22
-->

<!--
Thank you for your contribution to fgh!
-->
