### PR TITLE
🐛 Fix `fgh migrate`

### DIFF
--- a/pkg/repos/repos.go
+++ b/pkg/repos/repos.go
@@ -27,6 +27,10 @@ func Repos(rootPath string, ignoreErr bool) ([]LocalRepo, utils.CtxErr) {
 				return err
 			}
 
+			if !info.IsDir() {
+				return nil
+			}
+
 			isRepo, errInfo := IsGitRepo(path)
 			if errInfo.Error != nil {
 				errCtx = errInfo


### PR DESCRIPTION
## Description

<!--
Describe your changes in detail
-->

This miniature PR fixes `fgh migrate`, which was broken because it didn't ensure the dirent was a directory before calling `IsGitRepo()`, which seems to only work on directories.

## Steps

- [ ] My change requires a change to the documentation
- [ ] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #NaN

<!--
Example:
This PR resolves #22
-->

<!--
Thank you for your contribution to fgh!
-->
